### PR TITLE
root module requires signalfx

### DIFF
--- a/terraform/modules/workload-identity-pool/main.tf
+++ b/terraform/modules/workload-identity-pool/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "~> 9.0" # pick your floor
+    }
+  }
+}
+
 locals {
   is_aws_realm = local.realms_config[var.realm_name]["type"] == "aws"
   pool_id      = length(var.custom_pool_name) > 0 ? var.custom_pool_name : "splunk-identity-pool-${var.realm_name}"


### PR DESCRIPTION
To pair splunk and GCP this provider is necessary as it says in the sample dir using `signalfx_gcp_integration`. Otherwise it will fail with this error:

```
╷
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider
│ hashicorp/signalfx: provider registry registry.terraform.io does not have a
│ provider named registry.terraform.io/hashicorp/signalfx
│ 
│ Did you intend to use splunk-terraform/signalfx? If so, you must specify
│ that source address in each module which requires that provider. To see
│ which modules are currently depending on hashicorp/signalfx, run the
│ following command:
│     terraform providers
╵
```

If this PR is not necessary, please consider informing the readers via README to apply this provider explicitly.