### PR TITLE
default gcloud to none binding condition

### DIFF
--- a/cli/setup_wif.py
+++ b/cli/setup_wif.py
@@ -64,7 +64,8 @@ class AWSWIFProvider(WIFProvider):
         command = [
             "gcloud", "projects", "add-iam-policy-binding", project_id,
             "--member", member,
-            "--role", role
+            "--role", role,
+            "--condition=None"
         ]
         return run_command(command, dry_run=self.dry_run)
 
@@ -106,7 +107,8 @@ class GCPWIFProvider(WIFProvider):
         command = [
             "gcloud", "projects", "add-iam-policy-binding", project_id,
             "--member", member,
-            "--role", role
+            "--role", role,
+            "--condition=None"
         ]
         return run_command(command, dry_run=self.dry_run)
 


### PR DESCRIPTION
https://github.com/signalfx/gcp_workload_identity_federation/issues/9

That error means the project’s IAM policy already has conditional bindings. When that’s true, gcloud won’t let you add a new binding without saying whether it’s conditional or not.